### PR TITLE
Add an `OptStructArc` variant to wrap constructed structs in `Arc`

### DIFF
--- a/examples/optstrcut_arc_demo.rs
+++ b/examples/optstrcut_arc_demo.rs
@@ -1,0 +1,18 @@
+use std::{any::Any, sync::Arc};
+
+#[derive(optargs::OptStructArc)]
+struct Example {
+    a: i32,
+    b: Option<String>,
+}
+
+fn main() {
+    let ex1: Arc<Example> = Example! {
+        a: 10,
+        b: "asd".into()
+    };
+    let ex2: Arc<dyn Any> = Example! {
+        a: 10,
+        b: "asd".into()
+    };
+}

--- a/optargs-macro/src/lib.rs
+++ b/optargs-macro/src/lib.rs
@@ -3,6 +3,7 @@ use quote::ToTokens;
 
 mod optfn;
 mod optstruct;
+mod optstruct_arc;
 
 #[proc_macro_attribute]
 pub fn optfn(_attr: TokenStream, s: TokenStream) -> TokenStream {
@@ -15,6 +16,14 @@ pub fn optfn(_attr: TokenStream, s: TokenStream) -> TokenStream {
 #[proc_macro_derive(OptStruct, attributes(builder))]
 pub fn optstruct(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     match syn::parse::<optstruct::OptStruct>(input) {
+        Err(e) => e.to_compile_error().into(),
+        Ok(s) => s.to_token_stream().into(),
+    }
+}
+
+#[proc_macro_derive(OptStructArc, attributes(builder))]
+pub fn optstruct_arc(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    match syn::parse::<optstruct_arc::OptStructArc>(input) {
         Err(e) => e.to_compile_error().into(),
         Ok(s) => s.to_token_stream().into(),
     }

--- a/optargs-macro/src/optstruct.rs
+++ b/optargs-macro/src/optstruct.rs
@@ -157,7 +157,8 @@ impl Parse for OptStruct {
 
 impl ToTokens for OptStruct {
     fn to_tokens(&self, tokens: &mut TokenStream2) {
-        let (name, helper_defs, inners_body, call_body, validator) = OptStructConf::prepare_generate_tokens(&self.conf);
+        let (name, helper_defs, inners_body, call_body, validator) =
+            OptStructConf::prepare_generate_tokens(&self.conf);
 
         ToTokens::to_tokens(
             &quote! {

--- a/optargs-macro/src/optstruct_arc.rs
+++ b/optargs-macro/src/optstruct_arc.rs
@@ -1,0 +1,52 @@
+use proc_macro2::TokenStream as TokenStream2;
+use quote::{quote, ToTokens};
+use syn::parse::{Parse, ParseStream};
+use syn::Result;
+
+use crate::optstruct::OptStructConf;
+
+pub struct OptStructArc {
+    conf: OptStructConf,
+}
+
+impl Parse for OptStructArc {
+    fn parse(input: ParseStream) -> Result<Self> {
+        OptStructConf::parse(input).map(|conf| Self { conf })
+    }
+}
+
+impl ToTokens for OptStructArc {
+    fn to_tokens(&self, tokens: &mut TokenStream2) {
+        let (name, helper_defs, inners_body, call_body, validator) =
+            OptStructConf::prepare_generate_tokens(&self.conf);
+
+        ToTokens::to_tokens(
+            &quote! {
+
+                #[doc(hidden)]
+                #[macro_export]
+                macro_rules! #name {
+                    ($($key:ident $(: $value:expr)? ), * $(,)?) => {
+                        {
+                            #[allow(unused_mut)]
+                            let mut inners = (#( #inners_body )*);
+                            { $( #name! (@setter_helper inners $key $key $($value)? ); )* }
+                            #validator
+
+                            #[allow(unused_mut)]
+                            let mut validator = Validator::builder();
+                            validator $(.$key())* .build();
+
+                            std::sync::Arc::new(#name{
+                                #( #call_body )*
+                            })
+                        }
+                    };
+                    #( #helper_defs )*
+                }
+
+            },
+            tokens,
+        );
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,3 +50,26 @@ pub use optargs_macro::optfn;
 /// };
 /// ```
 pub use optargs_macro::OptStruct;
+
+/// Flexible struct builder with optional arguments. Wrapped in an `std::sync::Arc`
+/// Derive OptStruct for your structs and then call the Struct's name as a macro to build it with an `std::sync::Arc` wrapper applied, eliding optionals.
+///
+/// Note that this still obeys traditional macro_rules, so you can only use the macro *after* declaration or import it from "crate".
+///
+/// ```rust
+/// #[derive(optargs::OptStructArc)]
+/// pub struct Scatter {
+///     x: Vec<i32>,
+///     y: Option<Vec<i32>>,
+///     title: Option<&str>,
+///     xlabel: Option<&str>,
+///     ylabel: Option<&str>,
+///     legend: Option<bool>
+/// }
+///
+/// let plot = Scatter!{
+///     x: vec![1,2,3],
+///     legend: true
+/// };
+/// `
+pub use optargs_macro::OptStructArc;


### PR DESCRIPTION
(This is a proof-of-concept PR in case anyone is also interested in this functionality)

While using this incredible crate, I encountered a usage pattern where the constructed results almost 100% go inside an `Arc`, and the code would be much much more nicer if the macro would just produce `Arc<T>` instead of `T`. So I went ahead and added `OptStructArc` variant derive macro.

While in theory, we should be able generalize this to any smart pointer, or even any "post-build processing", I found my proc macro skill to be the limiting factor. Hence this solution is a makeshift one. Nevertheless, this PR does not simply duplicate stuff and it would be quite easy to extend other smart pointer variant on top of this work.

MSRV impact: used RPIT syntax which requires Rust >=1.26